### PR TITLE
Fix examples of obvious bugs/inconsistencies detected by phan (example)

### DIFF
--- a/core/lib/Drupal/Core/Cache/Context/LanguagesCacheContext.php
+++ b/core/lib/Drupal/Core/Cache/Context/LanguagesCacheContext.php
@@ -13,7 +13,7 @@ class LanguagesCacheContext implements CalculatedCacheContextInterface {
   /**
    * The language manager.
    *
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   * @var \Drupal\Core\Language\LanguageManagerInterface
    */
   protected $languageManager;
 

--- a/core/lib/Drupal/Core/Config/ConfigImporter.php
+++ b/core/lib/Drupal/Core/Config/ConfigImporter.php
@@ -394,7 +394,7 @@ class ConfigImporter {
     //  0 0 ban
     //  0 1 actions
     // @todo Move this sorting functionality to the extension system.
-    array_multisort(array_values($module_list), SORT_ASC, array_keys($module_list), SORT_DESC, $module_list);
+    array_multisort($module_list, SORT_ASC, array_keys($module_list), SORT_DESC, $module_list);
     $this->extensionChangelist['module']['uninstall'] = array_intersect(array_keys($module_list), $uninstall);
 
     // Determine which modules to install.

--- a/core/lib/Drupal/Core/Database/StatementPrefetch.php
+++ b/core/lib/Drupal/Core/Database/StatementPrefetch.php
@@ -282,7 +282,7 @@ class StatementPrefetch implements \Iterator, StatementInterface {
         case \PDO::FETCH_OBJ:
           return (object) $this->currentRow;
         case \PDO::FETCH_CLASS | \PDO::FETCH_CLASSTYPE:
-          $class_name = array_unshift($this->currentRow);
+          $class_name = array_shift($this->currentRow);
           // Deliberate no break.
         case \PDO::FETCH_CLASS:
           if (!isset($class_name)) {

--- a/core/lib/Drupal/Core/Datetime/DateHelper.php
+++ b/core/lib/Drupal/Core/Datetime/DateHelper.php
@@ -514,7 +514,7 @@ class DateHelper {
    * @param mixed $date
    *   (optional) A DrupalDateTime object or a date string.
    *   Defaults to NULL, which means use the current date.
-   * @param string $abbr
+   * @param bool $abbr
    *   (optional) Whether to return the abbreviated name for that day.
    *   Defaults to TRUE.
    *

--- a/core/lib/Drupal/Core/Entity/EntityFieldManager.php
+++ b/core/lib/Drupal/Core/Entity/EntityFieldManager.php
@@ -60,7 +60,7 @@ class EntityFieldManager implements EntityFieldManagerInterface {
    *   - type: The field type.
    *   - bundles: The bundles in which the field appears.
    *
-   * @return array
+   * @var array
    */
   protected $fieldMap = [];
 

--- a/core/lib/Drupal/Core/Entity/EntityViewBuilder.php
+++ b/core/lib/Drupal/Core/Entity/EntityViewBuilder.php
@@ -52,7 +52,7 @@ class EntityViewBuilder extends EntityHandlerBase implements EntityHandlerInterf
   /**
    * The language manager.
    *
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   * @var \Drupal\Core\Language\LanguageManagerInterface $language_manager
    */
   protected $languageManager;
 
@@ -68,7 +68,7 @@ class EntityViewBuilder extends EntityHandlerBase implements EntityHandlerInterf
    *
    * @see \Drupal\Core\Entity\EntityViewBuilder::getSingleFieldDisplay()
    *
-   * @param \Drupal\Core\Entity\Display\EntityViewDisplayInterface[]
+   * @var \Drupal\Core\Entity\Display\EntityViewDisplayInterface[]
    */
   protected $singleFieldDisplays;
 

--- a/core/lib/Drupal/Core/Plugin/Context/ContextDefinition.php
+++ b/core/lib/Drupal/Core/Plugin/Context/ContextDefinition.php
@@ -17,7 +17,7 @@ class ContextDefinition implements ContextDefinitionInterface {
   /**
    * The data type of the data.
    *
-   * @return string
+   * @var string
    *   The data type.
    */
   protected $dataType;
@@ -25,7 +25,7 @@ class ContextDefinition implements ContextDefinitionInterface {
   /**
    * The human-readable label.
    *
-   * @return string
+   * @var string
    *   The label.
    */
   protected $label;
@@ -33,7 +33,7 @@ class ContextDefinition implements ContextDefinitionInterface {
   /**
    * The human-readable description.
    *
-   * @return string|null
+   * @var string|null
    *   The description, or NULL if no description is available.
    */
   protected $description;

--- a/core/lib/Drupal/Core/Template/TwigTransTokenParser.php
+++ b/core/lib/Drupal/Core/Template/TwigTransTokenParser.php
@@ -96,7 +96,7 @@ class TwigTransTokenParser extends \Twig_TokenParser {
       ) {
         continue;
       }
-      throw new \Twig_Error_Syntax(sprintf('The text to be translated with "trans" can only contain references to simple variables'), $lineno);
+      throw new \Twig_Error_Syntax('The text to be translated with "trans" can only contain references to simple variables');
     }
   }
 

--- a/core/modules/comment/src/Plugin/Field/FieldFormatter/CommentDefaultFormatter.php
+++ b/core/modules/comment/src/Plugin/Field/FieldFormatter/CommentDefaultFormatter.php
@@ -78,7 +78,7 @@ class CommentDefaultFormatter extends FormatterBase implements ContainerFactoryP
   protected $entityFormBuilder;
 
   /**
-   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   * @var \Drupal\Core\Routing\RouteMatchInterface
    */
   protected $routeMatch;
 

--- a/core/modules/config_translation/config_translation.api.php
+++ b/core/modules/config_translation/config_translation.api.php
@@ -1,5 +1,7 @@
 <?php
 
+use Symfony\Component\Routing\Exception\RouteNotFoundException;
+
 /**
  * @file
  * Hooks provided by the Configuration Translation module.

--- a/core/modules/config_translation/src/ConfigNamesMapper.php
+++ b/core/modules/config_translation/src/ConfigNamesMapper.php
@@ -61,7 +61,7 @@ class ConfigNamesMapper extends PluginBase implements ConfigMapperInterface, Con
   /**
    * The base route object that the mapper is attached to.
    *
-   * @return \Symfony\Component\Routing\Route
+   * @var \Symfony\Component\Routing\Route
    */
   protected $baseRoute;
 

--- a/core/modules/config_translation/src/Controller/ConfigTranslationController.php
+++ b/core/modules/config_translation/src/Controller/ConfigTranslationController.php
@@ -62,7 +62,7 @@ class ConfigTranslationController extends ControllerBase {
   /**
    * The language manager.
    *
-   * @param \Drupal\Core\Language\LanguageManagerInterface $language_manager
+   * @var \Drupal\Core\Language\LanguageManagerInterface $language_manager
    */
   protected $languageManager;
 

--- a/core/modules/file/file.module
+++ b/core/modules/file/file.module
@@ -1556,7 +1556,7 @@ function file_icon_map($mime_type) {
  * @param \Drupal\Core\Field\FieldDefinitionInterface|null $field
  *   (optional) A field definition to be used for this check. If given,
  *   limits the reference check to the given field. Defaults to NULL.
- * @param int $age
+ * @param string $age
  *   (optional) A constant that specifies which references to count. Use
  *   EntityStorageInterface::FIELD_LOAD_REVISION (the default) to retrieve all
  *   references within all revisions or

--- a/core/modules/hal/src/LinkManager/TypeLinkManager.php
+++ b/core/modules/hal/src/LinkManager/TypeLinkManager.php
@@ -5,6 +5,7 @@ namespace Drupal\hal\LinkManager;
 use Drupal\Core\Cache\Cache;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Config\Entity\ConfigEntityInterface;
 use Drupal\Core\Entity\EntityTypeBundleInfoInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;

--- a/core/modules/language/src/EventSubscriber/LanguageRequestSubscriber.php
+++ b/core/modules/language/src/EventSubscriber/LanguageRequestSubscriber.php
@@ -41,7 +41,7 @@ class LanguageRequestSubscriber implements EventSubscriberInterface {
   /**
    * The current active user.
    *
-   * @return \Drupal\Core\Session\AccountInterface
+   * @var \Drupal\Core\Session\AccountInterface
    */
   protected $currentUser;
 

--- a/core/modules/language/src/LanguageNegotiationMethodBase.php
+++ b/core/modules/language/src/LanguageNegotiationMethodBase.php
@@ -28,7 +28,7 @@ abstract class LanguageNegotiationMethodBase implements LanguageNegotiationMetho
   /**
    * The current active user.
    *
-   * @return \Drupal\Core\Session\AccountInterface
+   * @var \Drupal\Core\Session\AccountInterface
    */
   protected $currentUser;
 

--- a/core/modules/language/src/LanguageNegotiator.php
+++ b/core/modules/language/src/LanguageNegotiator.php
@@ -38,7 +38,7 @@ class LanguageNegotiator implements LanguageNegotiatorInterface {
   /**
    * The settings instance.
    *
-   * @return \Drupal\Core\Site\Settings
+   * @var \Drupal\Core\Site\Settings
    */
   protected $settings;
 
@@ -52,7 +52,7 @@ class LanguageNegotiator implements LanguageNegotiatorInterface {
   /**
    * The current active user.
    *
-   * @return \Drupal\Core\Session\AccountInterface
+   * @var \Drupal\Core\Session\AccountInterface
    */
   protected $currentUser;
 

--- a/core/modules/locale/locale.compare.inc
+++ b/core/modules/locale/locale.compare.inc
@@ -173,7 +173,7 @@ function locale_translation_default_translation_server() {
  *
  * @param array $projects
  *   Array of project names to check. Defaults to all translatable projects.
- * @param string $langcodes
+ * @param string[] $langcodes
  *   Array of language codes. Defaults to all translatable languages.
  *
  * @return array
@@ -204,7 +204,7 @@ function locale_translation_check_projects($projects = [], $langcodes = []) {
  *
  * @param array $projects
  *   Array of project names to check. Defaults to all translatable projects.
- * @param string $langcodes
+ * @param string[] $langcodes
  *   Array of language codes. Defaults to all translatable languages.
  */
 function locale_translation_check_projects_batch($projects = [], $langcodes = []) {

--- a/core/modules/search/src/SearchQuery.php
+++ b/core/modules/search/src/SearchQuery.php
@@ -492,7 +492,7 @@ class SearchQuery extends SelectExtender {
    *   measure of keyword relevance between 0 and 1.
    * @param array $arguments
    *   Query arguments needed to provide values to the score expression.
-   * @param float $multiply
+   * @param float|false $multiply
    *   If set, the score is multiplied with this value. However, all scores
    *   with multipliers are then divided by the total of all multipliers, so
    *   that overall, the normalization is maintained.

--- a/core/modules/serialization/src/Normalizer/EntityReferenceFieldItemNormalizer.php
+++ b/core/modules/serialization/src/Normalizer/EntityReferenceFieldItemNormalizer.php
@@ -66,7 +66,7 @@ class EntityReferenceFieldItemNormalizer extends FieldItemNormalizer {
       /** @var \Drupal\Core\Field\Plugin\Field\FieldType\EntityReferenceItem $field_item */
       $field_item = $context['target_instance'];
       if (empty($data['target_uuid'])) {
-        throw new InvalidArgumentException(sprintf('If provided "target_uuid" cannot be empty for field "%s".', $data['target_type'], $data['target_uuid'], $field_item->getName()));
+        throw new InvalidArgumentException(sprintf('If provided "target_uuid" cannot be empty for field "%s".', $field_item->getName()));
       }
       $target_type = $field_item->getFieldDefinition()->getSetting('target_type');
       if (!empty($data['target_type']) && $target_type !== $data['target_type']) {

--- a/core/modules/simpletest/src/AssertContentTrait.php
+++ b/core/modules/simpletest/src/AssertContentTrait.php
@@ -337,7 +337,7 @@ trait AssertContentTrait {
    *
    * @param string $href
    *   The full or partial value of the 'href' attribute of the anchor tag.
-   * @param string $index
+   * @param int $index
    *   Link position counting from zero.
    * @param string $message
    *   (optional) A message to display with the assertion. Do not translate

--- a/core/modules/views/src/Annotation/ViewsDisplay.php
+++ b/core/modules/views/src/Annotation/ViewsDisplay.php
@@ -109,9 +109,9 @@ class ViewsDisplay extends ViewsPluginAnnotationBase {
   public $base;
 
   /**
-   * The theme function used to render the display's output.
+   * The theme function used to render the display's output. (e.g.
    *
-   * @return string
+   * @var string
    */
   public $theme;
 


### PR DESCRIPTION
Fix miscellaneous bugs/bad phpdoc detected by static analysis

array_multisort expects a reference for the first parameter
(Can't sort by value, must sort by reference)
- I'm not sure of the impact of fixing this sort.

The bug fixes to core/ are free to use; I would have to split these up and look for related issues before creating actual patches 